### PR TITLE
New: 유저 API 및 s3 업로드/다운로드 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ repositories {
 }
 
 dependencies {
+	implementation platform("software.amazon.awssdk:bom:2.16.60")
+	implementation 'software.amazon.awssdk:s3'
+	implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.1.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/bakery/caker/controller/MemberController.java
+++ b/src/main/java/bakery/caker/controller/MemberController.java
@@ -1,22 +1,51 @@
 package bakery.caker.controller;
 
 import bakery.caker.config.LoginUser;
+import bakery.caker.dto.MemberRequestDTO;
 import bakery.caker.dto.MemberResponseDTO;
 import bakery.caker.dto.SessionUserDTO;
 import bakery.caker.service.MemberService;
+import bakery.caker.service.OAuthUserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.websocket.server.PathParam;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
+    private final OAuthUserService oAuthUserService;
+
+    @PostMapping("/postman")
+    public Object sessionTest(@RequestBody Map<String,Object> attribute) {
+        return oAuthUserService.loadUserPostman(attribute);
+    }
 
     @GetMapping("/account/profile")
     public MemberResponseDTO sessionMemberDetails(@LoginUser SessionUserDTO sessionUser) {
         return memberService.findSessionMember(sessionUser.getMemberId());
+    }
+
+    @GetMapping("/{memberId}")
+    public MemberResponseDTO memberDetails(@PathVariable Long memberId) {
+        return memberService.findMember(memberId);
+    }
+
+    @PatchMapping("/account/profile")
+    public MemberResponseDTO memberModify(@LoginUser SessionUserDTO sessionUser,
+                                          @RequestParam(value="nickname", required = false) String nickname,
+                                          @RequestParam(value="image", required = false)MultipartFile file) throws IOException {
+        return memberService.modifySessionMember(sessionUser.getMemberId(), nickname, file);
+    }
+
+    @DeleteMapping("/account")
+    public String memberDelete(@LoginUser SessionUserDTO sessionUser) {
+        return memberService.deleteSessionMember(sessionUser.getMemberId());
     }
 }

--- a/src/main/java/bakery/caker/domain/Member.java
+++ b/src/main/java/bakery/caker/domain/Member.java
@@ -1,6 +1,8 @@
 package bakery.caker.domain;
 
 import bakery.caker.config.Authority;
+import bakery.caker.dto.MemberRequestDTO;
+import bakery.caker.dto.MemberResponseDTO;
 import com.sun.istack.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -53,5 +55,17 @@ public class Member {
 
     public void updateAuthority(Authority authority) {
         this.authority = authority;
+    }
+
+    public void updateProfile(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateImage(String fileurl) {
+        this.image = fileurl;
+    }
+
+    public void updateDeleteFlag() {
+        this.deleteFlag = true;
     }
 }

--- a/src/main/java/bakery/caker/dto/MemberRequestDTO.java
+++ b/src/main/java/bakery/caker/dto/MemberRequestDTO.java
@@ -1,0 +1,18 @@
+package bakery.caker.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberRequestDTO {
+    private String nickname;
+    private String email;
+
+    @Builder
+    public MemberRequestDTO(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/bakery/caker/dto/MemberResponseDTO.java
+++ b/src/main/java/bakery/caker/dto/MemberResponseDTO.java
@@ -2,6 +2,7 @@ package bakery.caker.dto;
 
 import bakery.caker.config.Authority;
 import bakery.caker.domain.Member;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,13 +11,16 @@ import lombok.NoArgsConstructor;
 public class MemberResponseDTO {
     private String nickname;
     private String email;
-    private String image;
+    private String imageName;
+    private String imageUrl;
     private Authority role;
 
-    public MemberResponseDTO(Member entity) {
+    @Builder
+    public MemberResponseDTO(Member entity, String imageUrl) {
         this.nickname = entity.getNickname();
         this.email = entity.getEmail();
-        this.image = entity.getImage();
+        this.imageName = entity.getImage();
         this.role = entity.getAuthority();
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/bakery/caker/service/ImageUploadService.java
+++ b/src/main/java/bakery/caker/service/ImageUploadService.java
@@ -1,0 +1,121 @@
+package bakery.caker.service;
+
+import bakery.caker.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import javax.transaction.Transactional;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUploadService {
+
+    public static URL getS3UploadURL(S3Presigner presigner, String bucketName, String fileName) {
+        try {
+
+            PutObjectRequest objectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileName)
+                    .contentType(checkContentType(fileName))
+                    .build();
+
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10)) //링크가 유효한 시간
+                    .putObjectRequest(objectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
+            URL myURL = presignedRequest.url();
+            System.out.println("Presigned URL to upload a file to: " +myURL.toString());
+            System.out.println("Which HTTP method needs to be used when uploading a file: " +
+                    presignedRequest.httpRequest().method());
+
+            return myURL;
+
+        } catch (S3Exception e) {
+            e.getStackTrace();
+        }
+        return null;
+    }
+
+    public static void UploadImage(URL url, MultipartFile file) throws IOException {
+        String contentType = checkContentType(file.getOriginalFilename());
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Type", contentType);
+        connection.setRequestMethod("PUT");
+        connection.getOutputStream().write(file.getBytes());
+        connection.getResponseCode();
+        System.out.println("HTTP response code is " + connection.getResponseCode());
+    }
+
+    public static String getS3DownloadURL(S3Presigner presigner, String bucketName, String keyName) {
+
+        try {
+            GetObjectRequest getObjectRequest =
+                    GetObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(keyName)
+                            .build();
+
+            GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(60))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedGetObjectRequest =
+                    presigner.presignGetObject(getObjectPresignRequest);
+
+            //여기서 접근 url나옴
+            String url = presignedGetObjectRequest.url().toString();
+            System.out.println("Presigned URL: " + url);
+            return url;
+        } catch (S3Exception e) {
+            e.getStackTrace();
+        }
+        return null;
+    }
+
+
+
+    public static String checkContentType(String fileName) {
+        int extension = fileName.indexOf(".");
+        String contentType = fileName.substring(extension);;
+
+        if(ObjectUtils.isEmpty(contentType)){
+            return null;
+        } else {
+            if(contentType.contains("jpeg")) {
+                return "image/jpeg";
+            }
+            else if(contentType.contains("jpg")) {
+                return "image/jpg";
+            }
+            else if(contentType.contains("png")) {
+                return "image/png";
+            }
+            else{
+                return null;
+            }
+        }
+    }
+
+}

--- a/src/main/java/bakery/caker/service/MemberService.java
+++ b/src/main/java/bakery/caker/service/MemberService.java
@@ -1,19 +1,131 @@
 package bakery.caker.service;
 
 import bakery.caker.domain.Member;
+import bakery.caker.dto.MemberRequestDTO;
 import bakery.caker.dto.MemberResponseDTO;
 import bakery.caker.repository.MemberRepository;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
 
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Transactional
     public MemberResponseDTO findSessionMember(Long memberId) {
-        Member member = memberRepository.findMemberByMemberIdAndDeleteFlagIsFalse(memberId)
+        Member member = findMemberEntity(memberId);
+        String imageUrl = findProfileImage(memberId);
+        return new MemberResponseDTO(member, imageUrl);
+    }
+
+    @Transactional
+    public MemberResponseDTO findMember(Long memberId) {
+        Member member = findMemberEntity(memberId);
+        String imageUrl = findProfileImage(memberId);
+        return new MemberResponseDTO(member, imageUrl);
+    }
+
+    @Transactional
+    public MemberResponseDTO modifySessionMember(Long memberId, String nickname, MultipartFile file) throws IOException {
+        Member member = findMemberEntity(memberId);
+
+        if(file!=null) {
+            modifyMemberImage(memberId, file);
+        }
+
+        if(nickname!=null) {
+            member.updateProfile(nickname);
+        }
+
+        String imageUrl = findProfileImage(memberId);
+        return new MemberResponseDTO(member, imageUrl);
+    }
+
+    @Transactional
+    public void modifyMemberImage(Long memberId, MultipartFile file) throws IOException {
+        Member member = findMemberEntity(memberId);
+
+        S3Presigner presigner = createPresigner();
+        String fileName = makeFileName(file);
+
+        URL url = ImageUploadService.getS3UploadURL(presigner, this.bucket, fileName);
+
+        ImageUploadService.UploadImage(url, file);
+        presigner.close();
+
+        member.updateImage(fileName);
+    }
+
+    @Transactional
+    public String findProfileImage(Long memberId) {
+        Member member = findMemberEntity(memberId);
+        String fileName = member.getImage();
+
+        S3Presigner presigner = createPresigner();
+
+        String url = ImageUploadService.getS3DownloadURL(presigner, this.bucket, fileName);
+        presigner.close();
+        return url;
+    }
+
+    @Transactional
+    public String deleteSessionMember(Long memberId) {
+        try {
+            Member member = findMemberEntity(memberId);
+            member.updateDeleteFlag();
+            return "삭제완료";
+        }catch(Exception e) {
+            return "실패";
+        }
+    }
+
+    public Member findMemberEntity(Long memberId) {
+        return memberRepository.findMemberByMemberIdAndDeleteFlagIsFalse(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다 id= "+memberId));
-        return new MemberResponseDTO(member);
+    }
+
+    public AwsBasicCredentials createCredentials() {
+        return AwsBasicCredentials.create(this.accessKey,this.secretKey);
+    }
+
+    public S3Presigner createPresigner() {
+        return S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(createCredentials()))
+                .build();
+    }
+
+    public static String makeFileName(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        int extension = fileName.indexOf(".");
+        String contentType = fileName.substring(extension);
+
+        SimpleDateFormat date = new SimpleDateFormat("yyyyMMddHHmmss");
+        return "caker-profile-" + date.format(new Date()) + contentType;
     }
 }

--- a/src/main/java/bakery/caker/service/OAuthUserService.java
+++ b/src/main/java/bakery/caker/service/OAuthUserService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpSession;
 import java.util.Collections;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -47,5 +48,13 @@ public class OAuthUserService implements OAuth2UserService<OAuth2UserRequest, OA
             memberRepository.save(attributes.toEntity());
             return memberRepository.findMemberByKakaoId(attributes.getKakaoId());
         }
+    }
+
+    public Object loadUserPostman(Map<String,Object> attribute) {
+        OAuthAttributesDTO attributes = OAuthAttributesDTO.ofKakao(attribute);
+        Member member = saveOrUpdate(attributes);
+
+        httpSession.setAttribute("user",new SessionUserDTO(member));
+        return httpSession.getAttribute("user");
     }
 }


### PR DESCRIPTION
이미지 업로드의 경우
1)업로드 권한이 있는 url을 받는 부분
2)해당 url로 이미지를 실제로 업로드 하는 부분
이렇게 구성되어있는데, 사실 2번의 경우 프론트쪽에서 구현이 가능함.
이 presigned url 쓰는 이유중에 또 하나가 file자체를 서버로 안보내고도 업로드가 가능하다는점인데,
뭔가 그러면 유저 정보 수정시에 너무 많은 요청을 프론트측에서 처리해야할거같아서,
그냥 file 받아서 서버에서 업로드까지 하는식으로 구현

다운로드의 경우
1)s3로 파일이름(이게 key임)을 보내면
2)다운로드 권한이 있는 url 반환
해당 url로 접속하면 이미지 보임!

그 외에 간단한 user crud 제작함.

resolves #3 , resolves #9