### PR TITLE
Improve: 케이크 타입별 필터링

### DIFF
--- a/src/main/java/bakery/caker/config/SecurityConfig.java
+++ b/src/main/java/bakery/caker/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .authorizeRequests(authorize -> authorize
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() //preflight 처리
                         .mvcMatchers("**/oauth2/**", "/kakaologin", "/main", "/","/css/**","/images/**","/js/**","/profile").permitAll()
-                        .mvcMatchers(HttpMethod.GET, "/orders", "/orders/{loc_gu}/{loc_dong}", "/orders/{order_id}", "/orders/newOrder").permitAll()
+                        .mvcMatchers(HttpMethod.GET, "/orders", "/orders/{loc_gu}/{loc_dong}", "/orders/{order_id}", "/orders/newOrder", "/orders/type/{type}").permitAll()
                         .mvcMatchers(HttpMethod.GET, "/stores", "/stores/{store_id}", "/stores/recommends", "/stores/search").permitAll()
                         .mvcMatchers(HttpMethod.GET, "/orders/{order_id}/comments").permitAll()
 

--- a/src/main/java/bakery/caker/controller/SheetController.java
+++ b/src/main/java/bakery/caker/controller/SheetController.java
@@ -33,6 +33,11 @@ public class SheetController {
         return new ResponseEntity<>(sheetService.findLocOrders(locGu, locDong), HttpStatus.OK);
     }
 
+    @GetMapping("/type/{type}")
+    public ResponseEntity<?> filteredOrderListByType(@PathVariable("type") String type){
+        return new ResponseEntity<>(sheetService.findOrdersByType(type), HttpStatus.OK);
+    }
+
     @GetMapping("/{order_id}")
     public ResponseEntity<?> orderDetails(@PathVariable("order_id") Long orderId){
         return new ResponseEntity<>(sheetService.findOrder(orderId), HttpStatus.OK);

--- a/src/main/java/bakery/caker/repository/SheetRepository.java
+++ b/src/main/java/bakery/caker/repository/SheetRepository.java
@@ -13,4 +13,5 @@ public interface SheetRepository extends JpaRepository<Sheet, Long> {
     List<Sheet> findAllByLocationGuAndLocationDongAndFinishedFlag(String locationGu, String locationDong, Boolean finishedFlag);
     List<Sheet> findTop6ByFinishedFlagOrderByCreatedAtDesc(Boolean finishedFlag);
     List<Sheet> findAllByMemberAndFinishedFlagFalse(Member member);
+    List<Sheet> findAllByTypeAndFinishedFlagFalse(String type);
 }

--- a/src/main/java/bakery/caker/service/SheetService.java
+++ b/src/main/java/bakery/caker/service/SheetService.java
@@ -172,6 +172,18 @@ public class SheetService {
                 .build();
     }
 
+    //Type으로 order조회
+    public SheetsResponseDTO findOrdersByType(String type){
+
+        List<Sheet> sheetList = sheetRepository.findAllByTypeAndFinishedFlagFalse(type);
+        List<SheetResponseDTO> sheetResponse = returnSheetResponse(sheetList);
+
+
+        return SheetsResponseDTO.builder()
+                .sheetResponseDTOs(sheetResponse)
+                .build();
+    }
+
     //리스트로 orderResponse 돌려주기
     private List<SheetResponseDTO> returnSheetResponse(List<Sheet> sheets){
         List<SheetResponseDTO> sheetResponse = new ArrayList<>();


### PR DESCRIPTION
1. SheetController에 type 필터링 api 추가
2. SheetRepository에 type과 deleteFlag에 따라 Sheet 가져오는 쿼리 추가
3. SheetService에 SheetsDTO에 찾아온 리스트 넣는 비즈니스 로직 추가